### PR TITLE
Melhoria na pagina cadastro

### DIFF
--- a/src/app/app-cadastro/app-cadastro.component.html
+++ b/src/app/app-cadastro/app-cadastro.component.html
@@ -1,30 +1,85 @@
 <mat-grid-list cols="1" [rowHeight]="'100px'" [gutterSize]="'1px'">
-  <mat-grid-tile [colspan]="1" [rowspan]="1">Cadastro no BookShelf</mat-grid-tile>
+  <mat-grid-tile [colspan]="1" [rowspan]="1"
+    >Cadastro no BookShelf</mat-grid-tile
+  >
+  <mat-stepper [linear]="isLinear" #stepper></mat-stepper>
   <mat-card>
-    <img mat-card-image src="../../assets/imagens/cover2.png" alt="Cover do Cadastro de Usuários">
+    <img
+      mat-card-image
+      src="../../assets/imagens/cover2.png"
+      alt="Cover do Cadastro de Usuários"
+    />
     <form [formGroup]="formularioCadastro" (ngSubmit)="enviaCadastro()">
-      <mat-form-field>
-        <input matInput placeholder="Entre com seu nome" formControlName="nome">
-        <mat-error *ngIf="nome?.errors?.['required']">Será necessário seu nome.</mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <input matInput placeholder="Email de Login" formControlName="email">
-        <mat-error *ngIf="email?.errors?.['required']">Será necessário informar um e-mail</mat-error>
-        <mat-error *ngIf="email?.errors?.['email']">O formato do e-mail não é valido</mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <input matInput placeholder="Entre com senha" formControlName="senha" type="password">
-        <mat-error *ngIf="senha?.errors?.['required']">Esqueceu a senha</mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <input matInput placeholder="Confirme a senha anterior" formControlName="confirmaSenha" type="password">
-        <mat-error *ngIf="senha?.errors?.['required']">Entre coma a confirmação</mat-error>
-        <mat-error *ngIf="formularioCadastro.errors?.['senhaConfirmada']">Entre coma a confirmação</mat-error>
-      </mat-form-field>
-      <mat-card-footer>
+      <mat-horizontal-stepper>
+        <mat-step label="Nome" >
+          <mat-form-field>
+            <input
+              matInput
+              placeholder="Entre com seu nome"
+              formControlName="nome"
+            />
+            <mat-error *ngIf="nome?.errors?.['required']"
+              >Será necessário seu nome.</mat-error
+            >
+          </mat-form-field>
+          <div>
+          <button mat-button matStepperNext>Next</button>
+          </div>
+
+        </mat-step>
+        <mat-step label="E-mail">
+          <mat-form-field>
+            <input
+              matInput
+              placeholder="Email de Login"
+              formControlName="email"
+            />
+            <mat-error *ngIf="email?.errors?.['required']"
+              >Será necessário informar um e-mail</mat-error
+            >
+            <mat-error *ngIf="email?.errors?.['email']"
+              >O formato do e-mail não é valido</mat-error
+            >
+          </mat-form-field>
+          <div>
+          <button mat-button matStepperNext>Next</button>
+          </div>
+        </mat-step>
+        <mat-step label="Senha">
+          <mat-form-field>
+            <input
+              matInput
+              placeholder="Entre com senha"
+              formControlName="senha"
+              type="password"
+            />
+            <mat-error *ngIf="senha?.errors?.['required']"
+              >Esqueceu a senha</mat-error
+            >
+          </mat-form-field>
+          <mat-form-field>
+            <input
+              matInput
+              placeholder="Confirme a senha anterior"
+              formControlName="confirmaSenha"
+              type="password"
+            />
+            <mat-error *ngIf="senha?.errors?.['required']"
+              >Entre com a confirmação</mat-error
+            >
+            <mat-error *ngIf="formularioCadastro.errors?.['senhaConfirmada']"
+              >Entre com a confirmação</mat-error
+            >
+          </mat-form-field>
+          <div>
         <button mat-button color="accent" type="submit">Cadastrar</button>
-        <button mat-button color="primary">Fechar</button>
-      </mat-card-footer>
+        <button mat-button (click)="resetarCamposCadastro()" color="primary">Resetar</button>
+        </div>
+        </mat-step>
+      </mat-horizontal-stepper>
+
+
+
     </form>
   </mat-card>
 </mat-grid-list>

--- a/src/app/app-cadastro/app-cadastro.component.html
+++ b/src/app/app-cadastro/app-cadastro.component.html
@@ -32,7 +32,7 @@
             </button>
           </div>
         </mat-step>
-        <mat-step label="E-mail" >
+        <mat-step label="E-mail">
           <mat-form-field>
             <input
               matInput
@@ -96,8 +96,12 @@
 
           <div>
             <button
-              [disabled]="this.senha?.value == ''" mat-button color="accent"
-              type="submit" > Cadastrar
+              [disabled]="this.senha?.value == ''"
+              mat-button
+              color="accent"
+              type="submit"
+            >
+              Cadastrar
             </button>
             <button
               mat-button

--- a/src/app/app-cadastro/app-cadastro.component.scss
+++ b/src/app/app-cadastro/app-cadastro.component.scss
@@ -7,6 +7,11 @@ mat-grid-list{
   margin-right: auto;
   max-width: 920px;
 }
-mat-form-field{
+mat-form-field, mat-step{
   margin: 1%;
+}
+
+.next{
+    display: block;
+    margin: 0 -16px -16px -16px;
 }

--- a/src/app/app-cadastro/app-cadastro.component.ts
+++ b/src/app/app-cadastro/app-cadastro.component.ts
@@ -23,6 +23,9 @@ export function passwordMatchValidator(): ValidatorFn {
   styleUrls: ['./app-cadastro.component.scss']
 })
 export class AppCadastroComponent implements OnInit {
+  isLinear = false;
+  firstFormGroup!: FormGroup;
+  secondFormGroup!: FormGroup;
   formularioCadastro = this.loginBuilder.group({
     nome: new FormControl('', Validators.required),
     email: new FormControl('', [Validators.required, Validators.email]),
@@ -71,10 +74,9 @@ export class AppCadastroComponent implements OnInit {
         this.resetarCamposCadastro();
       });
   }
-  // #51 - Rotina para limpar campos de cadastro [10 pts]
   resetarCamposCadastro() {
     this.formularioCadastro.reset();
-    console.log('Limpou campos cadastro');
+    alert('Reset dos campos realizado com sucesso');
     this.formularioCadastro = new FormGroup({
       nome: new FormControl(null),
       email: new FormControl(null),
@@ -85,5 +87,6 @@ export class AppCadastroComponent implements OnInit {
   }
 
   ngOnInit(): void {
+
   }
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -65,7 +65,8 @@ const routes: Routes = [
     path: 'livros-psicologia', component: GenPsiComponent,   ...canActivate(enviarSemLogin)
   },
   {
-    path: 'livros-mes', component: ClassReportagemComponent
+    path: 'livros-mes', component: ClassReportagemComponent,     ...canActivate(enviarSemLogin)
+
   },
   {
     path: 'livros-teatro', component: ClassTeatroComponent
@@ -80,7 +81,8 @@ const routes: Routes = [
     path: 'livros-sagas', component: ClassSagasComponent
   },
   {
-    path: 'livros-vendidos', component: ClassVendidoComponent
+    path: 'livros-vendidos', component: ClassVendidoComponent,     ...canActivate(enviarSemLogin)
+
   },
   {
     path:'**', component: PageNotFoundComponent

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,12 +17,14 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatStepperModule } from '@angular/material/stepper';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HotToastModule } from '@ngneat/hot-toast';
 
 import { environment } from '../environments/environment';
+import { AppCadastroComponent } from './app-cadastro/app-cadastro.component';
 import { AppMaterialModule } from './app-compartilhado/app-material/app-material.module';
 import { AppLoginComponent } from './app-login/app-login.component';
 import { AppRoutingModule } from './app-routing.module';
@@ -30,9 +32,7 @@ import { AppComponent } from './app.component';
 import { CriticasModule } from './criticas/criticas.module';
 import { FeedComponent } from './feed/feed.component';
 import { NavegacaoComponent } from './navegacao/navegacao.component';
-import { AppCadastroComponent } from './app-cadastro/app-cadastro.component';
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
-import { VestibularesModule } from './vestibulares/vestibulares.module';
 
 
 
@@ -45,6 +45,7 @@ import { VestibularesModule } from './vestibulares/vestibulares.module';
     AppCadastroComponent,
     PageNotFoundComponent,
     AppLoginComponent,
+
   ],
   imports: [
     BrowserModule,
@@ -66,6 +67,7 @@ import { VestibularesModule } from './vestibulares/vestibulares.module';
     MatRadioModule,
     ReactiveFormsModule,
     CriticasModule,
+    MatStepperModule,
     provideFirebaseApp(() => initializeApp(environment.firebase)),
     provideAuth(() => getAuth()),
     provideDatabase(() => getDatabase()),
@@ -74,6 +76,5 @@ import { VestibularesModule } from './vestibulares/vestibulares.module';
     HotToastModule.forRoot()
   ],
   providers: [],
-  bootstrap: [AppComponent]
-})
+  bootstrap: [AppComponent]})
 export class AppModule { }


### PR DESCRIPTION
- [ ] Melhorias para Tela de Cadastro #21
Implementadas melhorias de SCSS e HTML para tela de cadastro do usuário tracionando para o sistema de passos do Material Design de acordo com o link:
https://material.angular.io/components/stepper/examples


Implementações extras:

- [x] No campo senha, da página de cadastro, foi inserida a opção de visualizar a senha digitada ou não.

- [ ] O botão "Próximo" agora fica desabilitado se o campo acima deste não estiver preenchido. 

- [ ] O Botão "Fechar foi alterado para "Resetar", e quando clicado este reseta o preenchimento que foi feito até então em todos os campos.
   Obs.: O erro no toast da página de cadastro não foi tratado nestes card pois já está sendo tratado por outro card, o card 18.